### PR TITLE
Fix/clang c++20 compile warnings

### DIFF
--- a/deelx.h
+++ b/deelx.h
@@ -363,7 +363,7 @@ template <class ELT> inline int CBufferT <ELT> :: Pop(ELT & el)
 
 template <class ELT> int CBufferT <ELT> :: Pop (CBufferT<ELT> & buf)
 {
-	int size, res = 1;
+	int size = 0, res = 1;
 	res = res && Pop(*(ELT*)&size);
 	buf.Restore(size);
 

--- a/deelx.h
+++ b/deelx.h
@@ -1818,9 +1818,9 @@ protected:
 		int   len;
 
 	public:
-		CHART_INFO(CHART c, int t, int p = 0, int l = 0) { ch = c; type = t; pos = p; len = l;    }
-		inline int operator == (const CHART_INFO & ci)   { return ch == ci.ch && type == ci.type; }
-		inline int operator != (const CHART_INFO & ci)   { return ! operator == (ci);             }
+		CHART_INFO(CHART c, int t, int p = 0, int l = 0)     { ch = c; type = t; pos = p; len = l;    }
+		inline int operator == (const CHART_INFO & ci) const { return ch == ci.ch && type == ci.type; }
+		inline int operator != (const CHART_INFO & ci) const { return ! operator == (ci);             }
 	};
 
 protected:


### PR DESCRIPTION
Fix the following 2 compile warnings which happen with LLVM 12 (Clang) compiler when compiling for C++20 language standard:

1st warning:

```
C/C++: deelx.h:367:8: warning: variable 'size' is used uninitialized whenever '&&' condition is false [-Wsometimes-uninitialized]
```

2nd warning:

```
C/C++: deelx.h:2421:11: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'CBuilderT<char>::CHART_INFO' and 'CBuilderT<char>::CHART_INFO') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
C/C++:                 if(next == CHART_INFO(RCHART('['), 1))
C/C++:                    ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~
...
C/C++: deelx.h:1822:14: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
C/C++:                 inline int operator == (const CHART_INFO & ci)   { return ch == ci.ch && type == ci.type; }
```
